### PR TITLE
Add page title into HTML document title.

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf8">
-    <title>Pangdox</title>
+    <title>{% if struct.title %}{{ struct.title }} - {% endif %}Pangdox</title>
     <link href="/styles/index.scss" rel="stylesheet">
     <script src="https://kit.fontawesome.com/48faac965d.js"></script>
 </head>


### PR DESCRIPTION
This adds title from the 'page' title as defined in the structure to the HTML document title when possible.