### PR TITLE
Add support for dark mode.

### DIFF
--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -4,3 +4,17 @@
     --accent-1: #DCD0C0;
     --accent-2: #C0B283;
 }
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #373737;
+        --fg-color: #F4F4F4;
+        --accent-1: #554b2b;
+        --accent-2: #514829;
+    }
+
+    body {
+        background: #000;
+        color: #FFF;
+    }
+}


### PR DESCRIPTION
Uses `prefers-color-scheme` to provide an alternate color scheme.