### PR TITLE
Replace Font-Awesome icons with embedded Feather icons.

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -102,3 +102,9 @@ a.button {
 .nowrap {
     white-space: nowrap;
 }
+
+.svg-icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: -3px;
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -5,10 +5,8 @@
     <title>{% if struct.title %}{{ struct.title }} - {% endif %}Pangdox</title>
     <link href="/styles/index.scss" rel="stylesheet">
     <link href="/assets/favicon.ico" rel="icon">
-    <link href="https://kit-pro.fontawesome.com" rel="preconnect">
     <meta name="viewport" content= "width=device-width, initial-scale=1.0">
     <meta name="description" content="Unofficial documentation for the communication protocol of the 2004 MMORPG, PangYa.">
-    <script src="https://kit.fontawesome.com/48faac965d.js"></script>
 </head>
 <body>
     <main>
@@ -46,7 +44,7 @@
             </ul>
         </aside>
         <article>
-            <a class="float-right button floating-github-button" href="https://github.com/pangbox/packetdoc/edit/master/{{ repopath }}"><i class="fal fa-edit"></i> Edit on GitHub</a>
+            <a class="float-right button floating-github-button" href="https://github.com/pangbox/packetdoc/edit/master/{{ repopath }}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" class="svg-icon"><use href="#edit-icon" /></svg> Edit on GitHub</a>
         {% block body %}
         {% endblock %}
         </article>
@@ -68,5 +66,15 @@
             informational purposes.
         </p>
     </footer>
+    <!-- Based on feather icons, by Cole Bemis, under the MIT license. -->
+    <!-- https://github.com/feathericons/feather/blob/master/LICENSE -->
+    <svg xmlns="http://www.w3.org/2000/svg">
+        <symbol id="edit-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+        </symbol>
+        <symbol id="github-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+        </symbol>
+    </svg>
 </body>
 </html>

--- a/src/templates/packet.html
+++ b/src/templates/packet.html
@@ -38,8 +38,8 @@
     <h2>Definition</h2>
     <nav>
         <ul class="horizontal">
-            <li><a class="button" href="https://github.com/pangbox/packetdoc/blob/master/{{ repopath }}"><i class="fab fa-github-alt"></i> View on GitHub</a></li>
-            <li><a class="button" href="https://github.com/pangbox/packetdoc/edit/master/{{ repopath }}"><i class="fal fa-edit"></i> Edit on GitHub</a></li>
+            <li><a class="button" href="https://github.com/pangbox/packetdoc/blob/master/{{ repopath }}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" class="svg-icon"><use href="#github-icon" /></svg>  View on GitHub</a></li>
+            <li><a class="button" href="https://github.com/pangbox/packetdoc/edit/master/{{ repopath }}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" class="svg-icon"><use href="#edit-icon" /></svg> Edit on GitHub</a></li>
         </ul>
     </nav>
     <div class="source"><code><pre>{{ file.raw | stripdocs | yaml | highlight }}</pre></code></div>


### PR DESCRIPTION
We don't need many SVG icons, so it doesn't really make a ton of sense to load Font Awesome. Instead, we embed two Feather icons and use SVG symbols to link to them in the page.