### PR TITLE
loginservice: Document US852 server boosts

### DIFF
--- a/src/packets/loginservice/server/0002.ksy
+++ b/src/packets/loginservice/server/0002.ksy
@@ -68,7 +68,7 @@ types:
           0x10: Triple Exp
           0x80: Club Mastery
       - id: unknown4
-        size: 7
+        size: 6
         doc: More unknown bytes.
       - id: char_icon
         type: u2

--- a/src/packets/loginservice/server/0002.ksy
+++ b/src/packets/loginservice/server/0002.ksy
@@ -55,7 +55,20 @@ types:
           This field contains server flags. The meaning of each bit differs
           per region.
       - id: unknown3
-        size: 14
+        size: 6
+        doc: More unknown bytes.
+      - id: boosts
+        type: u2
+        doc: |
+          This field contains the active server boosts.
+          In the case of US 852, the following bits apply:
+          0x1: Double Pang
+          0x4: Double Exp
+          0x8: Angel Event
+          0x10: Triple Exp
+          0x80: Club Mastery
+      - id: unknown4
+        size: 7
         doc: More unknown bytes.
       - id: char_icon
         type: u2


### PR DESCRIPTION
This PR documents the possible server boosts found in the US852 version of the game contained in the loginservice2c packet 0x2.