### PR TITLE
My Room: A new explanation for why there are two user IDs.

### DIFF
--- a/src/packets/gameservice/client/00b5.ksy
+++ b/src/packets/gameservice/client/00b5.ksy
@@ -10,11 +10,9 @@ meta:
     - ../../common/pstring
 
 doc: |
-  This packet is one of two that signals the user has opened the inventory screen.
-  
-  Given that the user ID appears twice, it might be that this packet might also be used by administration to
-  open another user's inventory (one field might be for the local user ID for a permissions check, and the other for the target user ID).
-  This is entirely hypothetical, however.
+  This packet is one of two that signals the user has opened my room.
+
+  In newer seasons, you can't enter another user's room, so the `room_user_id` will always be the same as the `user_id`.
   
   The response is [GameService Server 0x012B Inventory Open A Response](/packets/gameservice/server/012b.ksy).
   
@@ -25,9 +23,9 @@ doc: |
   * `eantoniobr/UGPangya`: `PLAYER_ENTER_ROOM`
 
 seq:
-  - id: user_id_a
+  - id: user_id
     type: u4
     doc: User's ID
-  - id: user_id_b
+  - id: room_user_id
     type: u4
-    doc: User's ID (duplicate?)
+    doc: ID of user whose room is being entered


### PR DESCRIPTION
I haven't confirmed this since I do not have a way to try earlier seasons, but I believe it is likely that the reason why there are two user IDs is due to the fact that in older seasons, it used to be possible to enter another user's room. Why the connecting user must specify their own user ID is still not totally known, but I think that most likely this solves the mystery of why there are two.

Even if this is true, they could possibly be in the other order. Hard to tell.