### PR TITLE
document game service packet 0x131

### DIFF
--- a/src/packets/gameservice/server/0131.ksy
+++ b/src/packets/gameservice/server/0131.ksy
@@ -2,15 +2,15 @@
 #pragma.parseAs GameserviceServerPacket
 ---
 meta:
-  id: gameservice_server_0131_unknown
-  title: GameService Server 0131 Unknown
+  id: gameservice_server_treasure_hunter_info
+  title: GameService Server Treasure Hunter Info
   encoding: ASCII
   endian: le
   imports:
     - ../../common/pstring
 
 doc: |
-  This packet has unknown meaning.
+  This packet contains the treasure hunter bar value for all courses visible while selecting the course.
   
   This is a response to [Gameservice Client 0x0002 Hello / Login](/packets/gameservice/client/0002.ksy),
   but it also apparently sent automatically at the top of the hour.
@@ -20,7 +20,6 @@ seq:
     type: u1
   - id: entry_count
     type: u1
-    doc: Only 21 (0x15) witnessed.
   - id: entries
     type: entry
     repeat: expr
@@ -29,9 +28,9 @@ seq:
 types:
   entry:
     seq:
-      - id: entry_index
+      - id: course_id
         type: u1
-        doc: Increments from 0x00 to (entry_count - 1)
+        doc: The course_id
       - id: entry_value
         type: u4
-        doc: All seen values multiples of 10, in no particular order.
+        doc: The treasure hunter value, based on some empirical tests the minimum value to display anything is 720 and the maximum is 1000.

--- a/src/packets/gameservice/server/index.ksy
+++ b/src/packets/gameservice/server/index.ksy
@@ -231,7 +231,7 @@ seq:
         0x012e: gameservice_server_012e_custom_asset_response
         0x012f: gameservice_server_012f_room_invite_send_response
         0x0130: gameservice_server_0130_room_invite_send_response
-        0x0131: gameservice_server_0131_unknown
+        0x0131: gameservice_server_treasure_hunter_info
         0x0132: gameservice_server_0132_treasure_point_status
         0x0133: gameservice_server_0133_treasure_point_result
         0x0134: gameservice_server_0134_treasure_point_winnings


### PR DESCRIPTION
Update the documentation around the packet 0x131 which is related to the treasure hunter info. I did some empirical testing to validate everything and the only thing that is not clear is why the possible value for something to appear ranges from 720-1000. 
![image](https://github.com/pangbox/packetdoc/assets/4876366/9783ecdc-e449-48a1-9de1-f93ca72aafd8)
